### PR TITLE
iDRAC6 (Mbedthis) returns 302 on HTTPS

### DIFF
--- a/http-default-accounts-fingerprints-nndefaccts.lua
+++ b/http-default-accounts-fingerprints-nndefaccts.lua
@@ -11051,7 +11051,7 @@ table.insert(fingerprints, {
     {path = "/"}
   },
   target_check = function (host, port, path, response)
-    local idrac6 = response.status == 301
+    local idrac6 = (response.status == 301 or response.status == 302)
                    and (response.header["server"] or ""):find("^Mbedthis%-Appweb/%d+%.")
     local idrac7 = response.status == 302
                    and response.header["server"] == "Embedthis-http"


### PR DESCRIPTION
In addition to 301 on HTTP (existing code)

Proof:
```
NSE: TCP SCANNER_IP:41882 > TARGET_IP:443 | CONNECT
NSE: TCP SCANNER_IP:41882 > TARGET_IP:443 | 00000000: 47 45 54 20 2f 20 48 54 54 50 2f 31 2e 31 0d 0a GET / HTTP/1.1  
00000010: 43 6f 6e 6e 65 63 74 69 6f 6e 3a 20 6b 65 65 70 Connection: keep
REDACTED
00000050: 6b 0d 0a 55 73 65 72 2d 41 67 65 6e 74 3a 20 4d k  User-Agent: M
REDACTED

NSOCK INFO [6.6240s] nsock_write(): Write request for 144 bytes to IOD #4 EID 123 [TARGET_IP:443]
NSOCK INFO [6.6240s] nsock_trace_handler_callback(): Callback: WRITE SUCCESS for EID 123 [TARGET_IP:443]
NSE: TCP SCANNER_IP:41882 > TARGET_IP:443 | SEND
NSOCK INFO [6.6240s] nsock_read(): Read request from IOD #4 [TARGET_IP:443] (timeout: 18000ms) EID 130
NSOCK INFO [6.6810s] nsock_trace_handler_callback(): Callback: READ SUCCESS for EID 130 [TARGET_IP:443] (268 bytes)
NSE: TCP SCANNER_IP:41882 < TARGET_IP:443 | 00000000: 48 54 54 50 2f 31 2e 31 20 33 30 32 20 4d 6f 76 HTTP/1.1 302 Mov
00000010: 65 64 20 54 65 6d 70 6f 72 61 72 69 6c 79 0d 0a ed Temporarily  
00000020: 44 61 74 65 3a 20 46 72 69 2c 20 30 39 20 4a 61 Date: Fri, 09 Ja
00000030: 6e 20 31 39 37 30 20 31 31 3a 32 38 3a 31 36 20 n 1970 11:28:16 
00000040: 47 4d 54 0d 0a 53 65 72 76 65 72 3a 20 4d 62 65 GMT  Server: Mbe
00000050: 64 74 68 69 73 2d 41 70 70 77 65 62 2f 32 2e 34 dthis-Appweb/2.4
00000060: 2e 32 0d 0a 45 54 61 67 3a 20 22 33 31 39 39 38 .2  ETag: "31998
00000070: 62 30 2d 33 65 31 2d 30 22 0d 0a 43 6f 6e 74 65 b0-3e1-0"  Conte
00000080: 6e 74 2d 6c 65 6e 67 74 68 3a 20 30 0d 0a 43 6f nt-length: 0  Co
00000090: 6e 6e 65 63 74 69 6f 6e 3a 20 6b 65 65 70 2d 61 nnection: keep-a
000000a0: 6c 69 76 65 0d 0a 4b 65 65 70 2d 41 6c 69 76 65 live  Keep-Alive
000000b0: 3a 20 74 69 6d 65 6f 75 74 3d 36 30 2c 20 6d 61 : timeout=60, ma
000000c0: 78 3d 32 30 30 30 0d 0a 4c 6f 63 61 74 69 6f 6e x=2000  Location
REDACTED
```