### PR TITLE
Dell iDRAC6/7 (Mbedthis): authResult==5 -> auth success

### DIFF
--- a/http-default-accounts-fingerprints-nndefaccts.lua
+++ b/http-default-accounts-fingerprints-nndefaccts.lua
@@ -11065,7 +11065,7 @@ table.insert(fingerprints, {
     local resp = http_post_simple(host, port, url.absolute(path, "data/login"),
                                  nil, {user=user, password=pass})
     return resp.status == 200
-           and (resp.body or ""):find("<authResult>0</authResult>", 1, true)
+           and (resp.body or ""):find("<authResult>[0|5]</authResult>", 1, false)
   end
 })
 


### PR DESCRIPTION
authResult==5 also means auth success. I didn't know what it means but I observed it.
Also in:
https://github.com/ztgrace/changeme/blob/3a6e2f774139c0fab90b18d74652063668f2bad4/creds/http/general/dell_idrac.yml#L11
https://github.com/rapid7/metasploit-framework/blob/f49bf7b09a56f48a814734a4b4a3937e0765257b/modules/auxiliary/scanner/http/dell_idrac.rb#L67

This code works in my testing but please review it carefully as I'm not used at all to write Lua!