### PR TITLE
modify polycom v2 to match title string variant

### DIFF
--- a/http-default-accounts-fingerprints-nndefaccts.lua
+++ b/http-default-accounts-fingerprints-nndefaccts.lua
@@ -5862,7 +5862,7 @@ table.insert(fingerprints, {
            and response.body
            and response.body:find("Polycom", 1, true)
            and response.body:find("submitLoginInfo", 1, true)
-           and response.body:lower():find("<title>polycom - configuration utility</title>", 1, true)
+           and response.body:lower():find("<title>poly%l- %- configuration utility</title>", 1)
            and get_tag(response.body, "input", {name="^password$", autocomplete="^off$"})
   end,
   login_combos = {

--- a/http-default-accounts-fingerprints-nndefaccts.lua
+++ b/http-default-accounts-fingerprints-nndefaccts.lua
@@ -5846,8 +5846,16 @@ table.insert(fingerprints, {
   },
   login_check = function (host, port, path, user, pass)
     local qstr = url.build_query({t=os.date("!%a, %d %b %Y %H:%M:%S GMT")})
+
+    local creds_alt = {username = user, password = pass, digest = false}
+    local resp_alt = http_post_simple(host, port,
+                                 url.absolute(path, "form-submit/auth.htm"),
+                                 {auth=creds_alt}, "")
+
     return try_http_auth(host, port, url.absolute(path, "auth.htm?" .. qstr),
                         user, pass, false)
+                        or
+                        (resp_alt.status == 200 and get_cookie(resp_alt,"session"))
   end
 })
 


### PR DESCRIPTION
came across an instance of this server that wasn't being recognized due to the title string being `<title>Poly - Configuration Utility</title>` rather than `<title>Polycom - Configuration Utility</title>` (missing the com part), so just modified the find string here to match that as well.